### PR TITLE
Fix issue: "Create ACL table" log not see in SONiC acl regression tes…

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -13,6 +13,7 @@ import ptf.mask as mask
 import ptf.packet as packet
 
 from common import reboot, port_toggle
+from common.devices import Localhost
 from loganalyzer import LogAnalyzer, LogAnalyzerError
 
 logger = logging.getLogger(__name__)
@@ -257,7 +258,7 @@ class BaseAclTest(object):
         dut.command('config acl update full {}'.format(remove_rules_dut_path))
 
     @pytest.fixture(scope='class', autouse=True)
-    def acl_rules(self, duthost, localhost, setup, acl_table):
+    def acl_rules(self, duthost, ansible_adhoc, setup, acl_table):
         """
         setup/teardown ACL rules based on test class requirements
         :param duthost: DUT host object
@@ -266,7 +267,7 @@ class BaseAclTest(object):
         :param acl_table: table creating fixture
         :return:
         """
-
+        localhost = Localhost(ansible_adhoc)
         loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='acl_rules')
         loganalyzer.load_common_config()
 

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -258,7 +258,7 @@ class BaseAclTest(object):
         dut.command('config acl update full {}'.format(remove_rules_dut_path))
 
     @pytest.fixture(scope='class', autouse=True)
-    def acl_rules(self, duthost, ansible_adhoc, setup, acl_table):
+    def acl_rules(self, duthost, testbed_devices, setup, acl_table):
         """
         setup/teardown ACL rules based on test class requirements
         :param duthost: DUT host object
@@ -267,7 +267,7 @@ class BaseAclTest(object):
         :param acl_table: table creating fixture
         :return:
         """
-        localhost = Localhost(ansible_adhoc)
+        localhost = testbed_devices['localhost']
         loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='acl_rules')
         loganalyzer.load_common_config()
 

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -52,7 +52,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, timeout=180, wait=1
                              delay=delay,
                              timeout=timeout)
 
-    if 'failed' in res['localhost']:
+    if 'failed' in res:
         if reboot_res.ready():
             logger.error('reboot result: {}'.format(reboot_res.get()))
         raise Exception('DUT did not shutdown')
@@ -69,7 +69,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, timeout=180, wait=1
                              delay=delay,
                              timeout=timeout
     )
-    if 'failed' in res['localhost']:
+    if 'failed' in res:
         raise Exception('DUT did not startup')
 
     logger.info('ssh has started up')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Fix issue: "Create ACL table" log not see in SONiC acl regression test. This issue is caused by fixture "localhost" defined in ansible_fixture.py. It will trigger ansible to ssh to localhost even if the connection type is "local"(and the ssh failed which causes the case fail). acl/test_acl.py used this fixture and failed before the test started, so that there is no "Create ACL table" log catched.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?

I noticed that platform/test_reboot.py also used a localhost object with similar scene, so I changed test_acl.py to create the localhost as platform/test_reboot.py do and the test passed. 

#### How did you verify/test it?

I run the test manually, and it passed after the fix.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
