### PR TITLE
[Mellanox] Adjust test cases for fan led support

### DIFF
--- a/tests/platform/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform/mellanox/mellanox_thermal_control_test_helper.py
@@ -347,7 +347,7 @@ class FanDrawerData:
             return 'red'
 
         for fan_data in self.fan_data_list:
-            if fan_data.get_expect_led_color():
+            if fan_data.get_expect_led_color() == 'red':
                 return 'red'
 
         return 'green'

--- a/tests/platform/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform/mellanox/mellanox_thermal_control_test_helper.py
@@ -605,22 +605,22 @@ class RandomFanStatusMocker(FanStatusMocker):
                     fan_data.mock_speed(random.randint(0, 100))
                     self.expected_data[fan_data.name] = [
                         drawer_data.name,
+                        drawer_data.get_expect_led_color(), 
                         fan_data.name,
                         '{}%'.format(fan_data.mocked_speed),
                         drawer_data.mocked_direction,
                         drawer_data.mocked_presence,
-                        fan_data.mocked_status,
-                        drawer_data.get_expect_led_color()
+                        fan_data.mocked_status
                     ]
                 else:
                     self.expected_data[fan_data.name] = [
                         drawer_data.name,
+                        'red',
                         fan_data.name,
                         'N/A',
                         'N/A',
                         'Not Present',
-                        'N/A',
-                        'red'
+                        'N/A'
                     ]
             except SysfsNotExistError as e:
                 logging.info('Failed to mock fan data: {}'.format(e))
@@ -637,7 +637,8 @@ class RandomFanStatusMocker(FanStatusMocker):
                 fan_data.mock_speed(speed)
 
                 self.expected_data[fan_data.name] = [
-                    'PSU{}'.format(index),
+                    'N/A',
+                    '',
                     fan_data.name,
                     '{}RPM'.format(fan_data.mocked_speed),
                     NOT_AVAILABLE,
@@ -659,6 +660,8 @@ class RandomFanStatusMocker(FanStatusMocker):
             if name in actual_data:
                 actual_fields = actual_data[name]
                 for i, expected_field in enumerate(fields):
+                    if name.find('psu') != -1 and i ==1: 
+                        continue # skip led status check for PSU because we don't mock it
                     if expected_field != actual_fields[i]:
                         logging.error('Check fan status for {} failed, ' \
                                      'expected: {}, actual: {}'.format(name, expected_field, actual_fields[i]))

--- a/tests/platform/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform/mellanox/mellanox_thermal_control_test_helper.py
@@ -566,6 +566,7 @@ class RandomFanStatusMocker(FanStatusMocker):
         """
         FanStatusMocker.__init__(self, dut)
         self.mock_helper = MockerHelper(dut)
+        self.drawer_list = []
         self.expected_data = {}
 
     def deinit(self):
@@ -590,6 +591,7 @@ class RandomFanStatusMocker(FanStatusMocker):
             try:
                 if (fan_index - 1) % MockerHelper.FAN_NUM_PER_DRAWER == 0:
                     drawer_data = FanDrawerData(self.mock_helper, naming_rule, drawer_index)
+                    self.drawer_list.append(drawer_data)
                     drawer_index += 1
                     presence = random.randint(0, 1)
                     drawer_data.mock_presence(presence)
@@ -605,7 +607,7 @@ class RandomFanStatusMocker(FanStatusMocker):
                     fan_data.mock_speed(random.randint(0, 100))
                     self.expected_data[fan_data.name] = [
                         drawer_data.name,
-                        drawer_data.get_expect_led_color(), 
+                        'N/A', # update this value later 
                         fan_data.name,
                         '{}%'.format(fan_data.mocked_speed),
                         drawer_data.mocked_direction,
@@ -625,6 +627,13 @@ class RandomFanStatusMocker(FanStatusMocker):
             except SysfsNotExistError as e:
                 logging.info('Failed to mock fan data: {}'.format(e))
                 continue
+
+        # update led color here
+        for drawer_data in self.drawer_list:
+            for fan_data in drawer_data.fan_data_list:
+                if drawer_data.mocked_presence == 'Present':
+                    expected_data = self.expected_data[fan_data.name]
+                    expected_data[1] = drawer_data.get_expect_led_color()
 
         dut_hwsku = self.mock_helper.dut.facts["hwsku"]
         psu_count = SWITCH_MODELS[dut_hwsku]["psus"]["number"]

--- a/tests/platform/test_platform_info.py
+++ b/tests/platform/test_platform_info.py
@@ -340,7 +340,7 @@ def test_show_platform_fanstatus(testbed_devices, mocker_factory):
     logging.info('Mock FAN status data...')
     mocker.mock_data()
     logging.info('Wait and check actual data with mocked FAN status data...')
-    result = check_cli_output_with_mocker(dut, mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 1)
+    result = check_cli_output_with_mocker(dut, mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 2)
 
     assert result, 'FAN mock data mismatch'
 
@@ -533,46 +533,46 @@ def test_thermal_control_fan_status(testbed_devices, mocker_factory):
             with loganalyzer:
                 logging.info('Mocking an absence FAN...')
                 single_fan_mocker.mock_absence()
-                check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 1)
+                check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 2)
 
             loganalyzer.expect_regex = [LOG_EXPECT_FAN_REMOVE_CLEAR_RE, LOG_EXPECT_INSUFFICIENT_FAN_NUM_CLEAR_RE]
             with loganalyzer:
                 logging.info('Make the absence FAN back to presence...')
                 single_fan_mocker.mock_presence()
-                check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 1)
+                check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 2)
 
         loganalyzer.expect_regex = [LOG_EXPECT_FAN_FAULT_RE, LOG_EXPECT_INSUFFICIENT_FAN_NUM_RE]
         with loganalyzer:
             logging.info('Mocking a fault FAN...')
             single_fan_mocker.mock_status(False)
-            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 1)
+            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 2)
 
         loganalyzer.expect_regex = [LOG_EXPECT_FAN_FAULT_CLEAR_RE, LOG_EXPECT_INSUFFICIENT_FAN_NUM_CLEAR_RE]
         with loganalyzer:
             logging.info('Mocking the fault FAN back to normal...')
             single_fan_mocker.mock_status(True)
-            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 1)
+            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 2)
         
         loganalyzer.expect_regex = [LOG_EXPECT_FAN_OVER_SPEED_RE]
         with loganalyzer:
             logging.info('Mocking an over speed FAN...')
             single_fan_mocker.mock_over_speed()
-            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 1)
+            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 2)
 
         loganalyzer.expect_regex = [LOG_EXPECT_FAN_OVER_SPEED_CLEAR_RE]
         with loganalyzer:
             logging.info('Make the over speed FAN back to normal...')
             single_fan_mocker.mock_normal_speed()
-            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 1)
+            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 2)
 
         loganalyzer.expect_regex = [LOG_EXPECT_FAN_UNDER_SPEED_RE]
         with loganalyzer:
             logging.info('Mocking an under speed FAN...')
             single_fan_mocker.mock_under_speed()
-            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 1)
+            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 2)
 
         loganalyzer.expect_regex = [LOG_EXPECT_FAN_UNDER_SPEED_CLEAR_RE]
         with loganalyzer:
             logging.info('Make the under speed FAN back to normal...')
             single_fan_mocker.mock_normal_speed()
-            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 1)
+            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 2)

--- a/tests/platform/test_platform_info.py
+++ b/tests/platform/test_platform_info.py
@@ -32,10 +32,14 @@ THERMAL_POLICY_INVALID_VALUE_FILE = 'invalid_value_policy.json'
 LOG_EXPECT_POLICY_FILE_INVALID = '.*Caught exception while initializing thermal manager.*'
 LOG_EXPECT_FAN_REMOVE_RE = '.*Fan removed warning:.*'
 LOG_EXPECT_FAN_REMOVE_CLEAR_RE = '.*Fan removed warning cleared:.*'
-LOG_EXPECT_FAN_UNDER_SPEED_RE = '.*Fan under speed warning:.*'
-LOG_EXPECT_FAN_UNDER_SPEED_CLEAR_RE = '.*Fan under speed warning cleared:.*'
-LOG_EXPECT_FAN_OVER_SPEED_RE = '.*Fan over speed warning:*'
-LOG_EXPECT_FAN_OVER_SPEED_CLEAR_RE = '.*Fan over speed warning cleared:.*'
+LOG_EXPECT_FAN_FAULT_RE = '.*Fan fault warning:.*'
+LOG_EXPECT_FAN_FAULT_CLEAR_RE = '.*Fan fault warning cleared:.*'
+LOG_EXPECT_FAN_UNDER_SPEED_RE = '.*Fan low speed warning:.*'
+LOG_EXPECT_FAN_UNDER_SPEED_CLEAR_RE = '.*Fan low speed warning cleared:.*'
+LOG_EXPECT_FAN_OVER_SPEED_RE = '.*Fan high speed warning:*'
+LOG_EXPECT_FAN_OVER_SPEED_CLEAR_RE = '.*Fan high speed warning cleared:.*'
+LOG_EXPECT_INSUFFICIENT_FAN_NUM_RE = '.*Insufficient number of working fans warning:.*'
+LOG_EXPECT_INSUFFICIENT_FAN_NUM_CLEAR_RE = '.*Insufficient number of working fans warning cleared:.*'
 
 
 def check_sensord_status(ans_host):
@@ -305,7 +309,7 @@ def test_show_platform_syseeprom(testbed_devices):
 def check_show_platform_fanstatus_output(lines):
     """
     @summary: Check basic output of 'show platform fan'. Expect output are:
-              "Fan Not detected" or a table of fan status data with 6 columns.
+              "Fan Not detected" or a table of fan status data with 8 columns.
     """
     assert len(lines) > 0, 'There must be at least one line output for show platform fans'
     if len(lines) == 1:
@@ -314,7 +318,7 @@ def check_show_platform_fanstatus_output(lines):
         assert len(lines) > 2, 'There must be at least two lines output for show platform fans if any FAN is detected'
         second_line = lines[1]
         field_ranges = get_field_range(second_line)
-        assert len(field_ranges) == 6, 'There must be 6 columns in output of show platform fans'
+        assert len(field_ranges) == 8, 'There must be 8 columns in output of show platform fans'
 
 
 def test_show_platform_fanstatus(testbed_devices, mocker_factory):
@@ -336,7 +340,7 @@ def test_show_platform_fanstatus(testbed_devices, mocker_factory):
     logging.info('Mock FAN status data...')
     mocker.mock_data()
     logging.info('Wait and check actual data with mocked FAN status data...')
-    result = check_cli_output_with_mocker(dut, mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME)
+    result = check_cli_output_with_mocker(dut, mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 1)
 
     assert result, 'FAN mock data mismatch'
 
@@ -525,38 +529,50 @@ def test_thermal_control_fan_status(testbed_devices, mocker_factory):
         time.sleep(THERMAL_CONTROL_TEST_WAIT_TIME)
 
         if single_fan_mocker.is_fan_removable():
-            loganalyzer.expect_regex = [LOG_EXPECT_FAN_REMOVE_RE]
+            loganalyzer.expect_regex = [LOG_EXPECT_FAN_REMOVE_RE, LOG_EXPECT_INSUFFICIENT_FAN_NUM_RE]
             with loganalyzer:
                 logging.info('Mocking an absence FAN...')
                 single_fan_mocker.mock_absence()
-                check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME)
+                check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 1)
 
-            loganalyzer.expect_regex = [LOG_EXPECT_FAN_REMOVE_CLEAR_RE]
+            loganalyzer.expect_regex = [LOG_EXPECT_FAN_REMOVE_CLEAR_RE, LOG_EXPECT_INSUFFICIENT_FAN_NUM_CLEAR_RE]
             with loganalyzer:
                 logging.info('Make the absence FAN back to presence...')
                 single_fan_mocker.mock_presence()
-                check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME)
+                check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 1)
 
+        loganalyzer.expect_regex = [LOG_EXPECT_FAN_FAULT_RE, LOG_EXPECT_INSUFFICIENT_FAN_NUM_RE]
+        with loganalyzer:
+            logging.info('Mocking a fault FAN...')
+            single_fan_mocker.mock_status(False)
+            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 1)
+
+        loganalyzer.expect_regex = [LOG_EXPECT_FAN_FAULT_CLEAR_RE, LOG_EXPECT_INSUFFICIENT_FAN_NUM_CLEAR_RE]
+        with loganalyzer:
+            logging.info('Mocking the fault FAN back to normal...')
+            single_fan_mocker.mock_status(True)
+            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 1)
+        
         loganalyzer.expect_regex = [LOG_EXPECT_FAN_OVER_SPEED_RE]
         with loganalyzer:
             logging.info('Mocking an over speed FAN...')
             single_fan_mocker.mock_over_speed()
-            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME)
+            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 1)
 
         loganalyzer.expect_regex = [LOG_EXPECT_FAN_OVER_SPEED_CLEAR_RE]
         with loganalyzer:
             logging.info('Make the over speed FAN back to normal...')
             single_fan_mocker.mock_normal_speed()
-            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME)
+            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 1)
 
         loganalyzer.expect_regex = [LOG_EXPECT_FAN_UNDER_SPEED_RE]
         with loganalyzer:
             logging.info('Mocking an under speed FAN...')
             single_fan_mocker.mock_under_speed()
-            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME)
+            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 1)
 
         loganalyzer.expect_regex = [LOG_EXPECT_FAN_UNDER_SPEED_CLEAR_RE]
         with loganalyzer:
             logging.info('Make the under speed FAN back to normal...')
             single_fan_mocker.mock_normal_speed()
-            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME)
+            check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 1)

--- a/tests/platform/thermal_control_test_helper.py
+++ b/tests/platform/thermal_control_test_helper.py
@@ -174,6 +174,14 @@ class SingleFanMocker(BaseMocker):
         """
         pass
 
+    def mock_status(self, status):
+        """
+        Change the mocked FAN status to good or bad
+        :param status: bool value indicate the target status of the FAN.
+        :return:
+        """
+        pass
+
     def mock_normal_speed(self):
         """
         Change the mocked FAN speed to a normal value.
@@ -254,7 +262,7 @@ def get_fields(line, field_ranges):
     return fields
 
 
-def check_cli_output_with_mocker(dut, mocker_object, command, max_wait_time):
+def check_cli_output_with_mocker(dut, mocker_object, command, max_wait_time, key_index=0):
     """
     Check the command line output matches the mocked data.
     :param dut: DUT object representing a SONiC switch under test. 
@@ -273,7 +281,7 @@ def check_cli_output_with_mocker(dut, mocker_object, command, max_wait_time):
     actual_data = {}
     for line in output["stdout_lines"][2:]:
         fields = get_fields(line, field_ranges)
-        actual_data[fields[0]] = fields
+        actual_data[fields[key_index]] = fields
     
     return mocker_object.check_result(actual_data)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Add test case for fan led management enhancement.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

1. Check drawer info and led status in output of  "show platform fan"
2. Check syslog for fan fault  

#### How did you verify/test it?

Manually run the test cases

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

All existing topologies

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
