### PR TITLE
[Mellanox] Rename group_vars/sonic/var to group_vars/sonic/variables to fix simx delpoy failure

### DIFF
--- a/ansible/README.deploy.md
+++ b/ansible/README.deploy.md
@@ -14,7 +14,7 @@ and public [sonicdev Docker registry](https://sonicdev-microsoft.azurecr.io/).
 - Update [inventory](/ansible/inventory/) file with correct information for your environment.
   - ansible_host = management ip address
   - sonic_hwsku = Supported Hardware SKU, e.g. Force10-S6000, ACS-MSN2700
-- Update [group_vars/sonic/vars](/ansible/group_vars/sonic/vars/) file with:
+- Update [group_vars/sonic/variables](/ansible/group_vars/sonic/variables/) file with:
   - Replace `sonicadmin_user` and `ansible_ssh_user` with the username you built into the baseimage
   - Replace `sonicadmin_initial_password` with the password you built into baseimage.
   - Update `[ntp,syslog,dns]_servers` with a list of your server IPs for these services.

--- a/ansible/roles/vm_set/tasks/start_sid.yml
+++ b/ansible/roles/vm_set/tasks/start_sid.yml
@@ -1,4 +1,4 @@
-- include_vars: group_vars/sonic/vars
+- include_vars: group_vars/sonic/variables
 
 - set_fact:
     sonic_hwsku: "{{ hostvars[dut_name]['hwsku'] }}"

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -124,7 +124,7 @@ def setup_teardown(request, testbed, duthost, ptfhost):
     ecn_mode = "copy_from_outer"
     ttl_mode = "pipe"
 
-    # The hostvars dict has definitions defined in ansible/group_vars/sonic/vars
+    # The hostvars dict has definitions defined in ansible/group_vars/sonic/variables
     hostvars = duthost.host.options["variable_manager"]._hostvars[duthost.hostname]
     sonic_hwsku = duthost.facts["hwsku"]
     mellanox_hwskus = hostvars["mellanox_hwskus"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Rename group_vars/sonic/var to group_vars/sonic/variables to fix simx delpoy failure

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

The file group_vars/sonic/var was renamed to group_vars/sonic/variables, but there are some places still ref to old file name in code. 

#### How did you do it?

Rename group_vars/sonic/var to group_vars/sonic/variables

#### How did you verify/test it?

Manually run the regression

#### Any platform specific information?

Mellanox SimX

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
