### PR TITLE
[Mellanox] Remove unsupported air flow direction from test_dynamic_minimum_table

### DIFF
--- a/tests/platform_tests/mellanox/test_thermal_control.py
+++ b/tests/platform_tests/mellanox/test_thermal_control.py
@@ -8,13 +8,15 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.utilities import wait_until
 from tests.platform_tests.thermal_control_test_helper import *
 from mellanox_thermal_control_test_helper import MockerHelper, AbnormalFanMocker
+from tabulate import tabulate
+import re
 
 pytestmark = [
     pytest.mark.asic('mellanox'),
     pytest.mark.topology('any')
 ]
 
-THERMAL_CONTROL_TEST_WAIT_TIME = 65
+THERMAL_CONTROL_TEST_WAIT_TIME = 75
 THERMAL_CONTROL_TEST_CHECK_INTERVAL = 5
 
 COOLING_CUR_STATE_PATH = '/run/hw-management/thermal/cooling_cur_state'
@@ -23,8 +25,6 @@ PSU_PRESENCE_PATH = '/run/hw-management/thermal/psu{}_status'
 PSU_SPEED_PATH = '/run/hw-management/thermal/psu{}_fan1_speed_get'
 PSU_MAX_SPEED_PATH = '/run/hw-management/config/psu_fan_max'
 PSU_SPEED_TOLERANCE = 0.25
-
-LOG_EXPECT_CHANGE_MIN_COOLING_LEVEL_RE = '.*Changed minimum cooling level to {}.*'
 
 
 @pytest.mark.disable_loganalyzer
@@ -37,29 +37,23 @@ def test_dynamic_minimum_table(duthosts, rand_one_dut_hostname, mocker_factory):
         pytest.skip('The cooling level {} is higher than threshold {}.'.format(cooling_cur_state, COOLING_CUR_STATE_THRESHOLD))
 
     mocker = mocker_factory(duthost, 'MinTableMocker')
-    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='thermal_control')
-    loganalyzer.load_common_config()
 
-    for index in range(len(air_flow_dirs)):
-        air_flow_index = random.randint(0, len(air_flow_dirs) - 1)
-        air_flow_dir = air_flow_dirs[air_flow_index]
-        air_flow_dirs.remove(air_flow_dir)
-        temperature = random.randint(0, max_temperature)
-        trust_state = True if random.randint(0, 1) else False
-        logging.info('Testing with air_flow_dir={}, temperature={}, trust_state={}'.format(air_flow_dir, temperature, trust_state))
-        expect_minimum_cooling_level = mocker.get_expect_cooling_level(air_flow_dir, temperature, trust_state)
-        loganalyzer.expect_regex = [LOG_EXPECT_CHANGE_MIN_COOLING_LEVEL_RE.format(expect_minimum_cooling_level)]
-        with loganalyzer:
-            mocker.mock_min_table(air_flow_dir, temperature, trust_state)
-            time.sleep(THERMAL_CONTROL_TEST_WAIT_TIME)
+    temperature = random.randint(0, max_temperature)
+    trust_state = True if random.randint(0, 1) else False
+    logging.info('Testing with temperature={}, trust_state={}'.format(temperature, trust_state))
+    expect_minimum_cooling_level = mocker.get_expect_cooling_level(temperature, trust_state)
+    mocker.mock_min_table(temperature, trust_state)
+    time.sleep(THERMAL_CONTROL_TEST_WAIT_TIME)
+    actual_cooling_level = get_cooling_cur_state(duthost)
+    assert actual_cooling_level >= expect_minimum_cooling_level, 'Cooling level {} is less than minimum allowed {}'.format(actual_cooling_level, expect_minimum_cooling_level)
 
-        temperature = random.randint(0, max_temperature)
-        logging.info('Testing with air_flow_dir={}, temperature={}, trust_state={}'.format(air_flow_dir, temperature, not trust_state))
-        expect_minimum_cooling_level = mocker.get_expect_cooling_level(air_flow_dir, temperature, not trust_state)
-        loganalyzer.expect_regex = [LOG_EXPECT_CHANGE_MIN_COOLING_LEVEL_RE.format(expect_minimum_cooling_level)]
-        with loganalyzer:
-            mocker.mock_min_table(air_flow_dir, temperature, not trust_state)
-            time.sleep(THERMAL_CONTROL_TEST_WAIT_TIME)
+    temperature = random.randint(0, max_temperature)
+    logging.info('Testing with temperature={}, trust_state={}'.format(temperature, not trust_state))
+    expect_minimum_cooling_level = mocker.get_expect_cooling_level(temperature, not trust_state)
+    mocker.mock_min_table(temperature, not trust_state)
+    time.sleep(THERMAL_CONTROL_TEST_WAIT_TIME)
+    actual_cooling_level = get_cooling_cur_state(duthost)
+    assert actual_cooling_level >= expect_minimum_cooling_level, 'Cooling level {} is less than minimum allowed {}'.format(actual_cooling_level, expect_minimum_cooling_level)
 
 
 @pytest.mark.disable_loganalyzer
@@ -89,11 +83,24 @@ def test_set_psu_fan_speed(duthosts, rand_one_dut_hostname, mocker_factory):
 
     logging.info('Mock FAN presence...')
     single_fan_mocker.mock_presence()
-    assert wait_until(THERMAL_CONTROL_TEST_WAIT_TIME, THERMAL_CONTROL_TEST_CHECK_INTERVAL, check_cooling_cur_state, duthost, 10, operator.ne), \
-        'Current cooling state is {}'.format(get_cooling_cur_state(duthost))
+    wait_until(THERMAL_CONTROL_TEST_WAIT_TIME, THERMAL_CONTROL_TEST_CHECK_INTERVAL, check_cooling_cur_state, duthost, 10, operator.ne)
     logging.info('Wait {} seconds for the policy to take effect...'.format(THERMAL_CONTROL_TEST_CHECK_INTERVAL))
     time.sleep(THERMAL_CONTROL_TEST_CHECK_INTERVAL)
     cooling_cur_state = get_cooling_cur_state(duthost)
+    if cooling_cur_state == 10:
+        cmd_output = str(duthost.command('show platform temperature')['stdout_lines'])
+        cmd_output = cmd_output.replace("u'", "").replace(',', " ")
+        cmd_output = re.split(r'  +',cmd_output)
+        cmd_output.pop(0)
+        j = 0
+        table = []
+        while j != len(cmd_output):
+            entry = []
+            for i in range(8):
+                entry.append(cmd_output[j + i])
+            table.append(entry)
+            j += 8
+        pytest.skip('Cooling level is still 10, ignore the rest test.\nIt might happen because the asic temperature is still high.\nCurrent system temperature:\n{}'.format(tabulate(table)))
     logging.info('Cooling level changed to {}'.format(cooling_cur_state))
     if cooling_cur_state < 6: # PSU fan speed will never be less than 60%
         cooling_cur_state = 6
@@ -114,8 +121,8 @@ def _check_psu_fan_speed_in_range(actual_speed, max_speed, cooling_level):
 def get_psu_speed(dut, index):
     index = index + 1
     psu_speed_path = PSU_SPEED_PATH.format(index)
-    file_exists = dut.stat(path=psu_speed_path)
-    if not file_exists:
+    file_stat = dut.stat(path=psu_speed_path)
+    if not file_stat["stat"]["exists"]:
         return None
 
     cmd_output = dut.command('cat {}'.format(psu_speed_path))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Remove unsupported fan direction from test_dynamic_minimum_table. And make test_set_psu_fan_speed more robust.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

1. It is hard to determine air flow direction at run time, so the current thermal control algorithm assumes that air flow direction is unknown. Remove unsupported air flow direction from test_dynamic_minimum_table. 
2. The fan speed might be adjusted by kernel. Make test_set_psu_fan_speed more robust. 

#### How did you do it?

1. Remove unsupported air flow direction check
2. When fan speed keep 100% after making all fan in normal state, skip test_set_psu_fan_speed

#### How did you verify/test it?

Manually run regression case

#### Any platform specific information?

Mellanox

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
