### PR TITLE
[Mellanox] Set fan max speed threshold from 0.1 to 0.2

### DIFF
--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -7,7 +7,7 @@ import logging
 from tests.common.mellanox_data import get_platform_data
 from tests.common.utilities import wait_until
 
-MAX_FAN_SPEED_THRESHOLD = 0.1
+MAX_FAN_SPEED_THRESHOLD = 0.2
 
 
 def check_sysfs(dut):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Set fan max speed threshold from 0.1 to 0.2

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Sometimes fan speed exceeds max speed over 10%, so set the threshold to 20% 

#### How did you do it?

Set fan max speed threshold from 0.1 to 0.2

#### How did you verify/test it?

Run the test manually

#### Any platform specific information?

Mellanox

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
