### PR TITLE
[Mellanox] Put non swapable fan to a virtual drawer to sync with production code

### DIFF
--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -144,7 +144,14 @@ class MockerHelper:
         content = output['stdout'].strip()
         if not content:
             return
+
         MockerHelper.FAN_NUM = int(content)
+        platform_data = get_platform_data(self.dut)
+        if not platform_data['fans']['hot_swappable']:
+            # For non swappable fan, there is no drawer. We put them in a "virtual" drawer.
+            MockerHelper.FAN_NUM_PER_DRAWER = MockerHelper.FAN_NUM
+            return
+
         if MockerHelper.FAN_NUM > fan_drawer_num:
             MockerHelper.FAN_NUM_PER_DRAWER = 2
         else:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Put non swapable fan to a virtual drawer to avoid sporadic failure

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

For all non swapable fans, they are put into a virtual drawer in production code. However, sonic-mgmt test cases put 2 fans in 1 drawer. This PR is to fix it.

#### How did you do it?

If the fan is non swapable, put it into a virtual drawer.

#### How did you verify/test it?

Run the test case and make sure it pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
