### PR TITLE
[test_platform_info] Add check for return value of PsuController.get_psu_status as it could return empty list

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -154,11 +154,11 @@ def check_vendor_specific_psustatus(dut, psu_status_line):
 
 def turn_all_psu_on(psu_ctrl):
     all_psu_status = psu_ctrl.get_psu_status()
-    if all_psu_status:
-        for psu in all_psu_status:
-            if not psu["psu_on"]:
-                psu_ctrl.turn_on_psu(psu["psu_id"])
-                time.sleep(5)
+    assert all_psu_status and len(all_psu_status) >= 2, 'Failed to get at least 2 PSU status: {}'.format(all_psu_status)
+    for psu in all_psu_status:
+        if not psu["psu_on"]:
+            psu_ctrl.turn_on_psu(psu["psu_id"])
+            time.sleep(5)
 
 
 def check_all_psu_on(dut, psu_test_results):
@@ -208,6 +208,7 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, rand_one_dut_hostname, ps
 
     logging.info("Start testing turn off/on PSUs")
     all_psu_status = psu_ctrl.get_psu_status()
+    assert all_psu_status and len(all_psu_status) >= 2, 'Failed to get at least 2 PSU status: {}'.format(all_psu_status)
     for psu in all_psu_status:
         psu_under_test = None
 
@@ -360,6 +361,7 @@ def test_thermal_control_psu_absence(duthosts, rand_one_dut_hostname, psu_contro
 
         logging.info('Shutdown first PSU and check thermal control result...')
         all_psu_status = psu_ctrl.get_psu_status()
+        assert all_psu_status and len(all_psu_status) >= 2, 'Failed to get at least 2 PSU status: {}'.format(all_psu_status)
         psu = all_psu_status[0]
         turn_off_psu_and_check_thermal_control(duthost, psu_ctrl, psu, fan_mocker)
         psu_test_results.clear()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add check for return value of PsuController.get_psu_status as it could return empty list

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

PsuController.get_psu_status could return empty list. If we continue the test, it might mislead test case results reviewer because test case could failed at other place if `get_psu_status ` return empty.

#### How did you do it?

Add an assertion after get_psu_status

#### How did you verify/test it?

Manual test

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
