### PR TITLE
Fix KeyError in test_thermal_control_psu_absence

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -392,7 +392,7 @@ def turn_off_outlet_and_check_thermal_control(dut, pdu_ctrl, outlet, mocker):
     @summary: Turn off PSUs, check all FAN speed are set to 100% according to thermal
               control policy file.
     """
-    logging.info("Turn off outlet %s" % str(outlet["psu_id"]))
+    logging.info("Turn off outlet %s" % str(outlet["outlet_id"]))
     pdu_ctrl.turn_off_outlet(outlet)
     time.sleep(5)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
There was a PSU controller refactor. Before the refactor, the API to get PSU status returns something like `{'psu_id': 0}`, but after it was changed to `{'outlet_id': 0}`. We need apply this change to all code that refer to this API

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Fix KeyError when running test_thermal_control_psu_absence

#### How did you do it?

Change the key from "psu_id" to "outlet_id"

#### How did you verify/test it?

Manually run the test

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
