### PR TITLE
[snmp_pdu_controllers] Fix pdu oid issue

### DIFF
--- a/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
+++ b/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
@@ -116,7 +116,7 @@ class snmpPduController(PduControllerBase):
         pdu_port_base = self.PORT_NAME_BASE_OID
         query_oid = '.' + pdu_port_base
         if self.has_lanes:
-            query_oid = query_oid + str(lane_id)
+            query_oid = query_oid + '.' + str(lane_id)
 
         errorIndication, errorStatus, errorIndex, varTable = cmdGen.nextCmd(
             snmp_auth,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes pdu oid issue. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Without the fix, the OID of lane 1 will be:
```
.1.3.6.1.4.1.1718.3.2.3.1.31
```

There should be a '.' between the last 3 and last 1

#### How did you do it?

Add a '.' if has_lanes is True

#### How did you verify/test it?

Manually run the test

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
