### PR TITLE
[Mellanox] Fix fan speed mock issue

### DIFF
--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -510,7 +510,7 @@ class FanData:
         """
         max_speed = self.get_max_speed()
         if max_speed > 0:
-            speed_in_rpm = max_speed * speed / 100
+            speed_in_rpm = int(round(float(max_speed) * speed / 100))
             self.helper.mock_thermal_value(self.speed_file, str(speed_in_rpm))
         else:
             self.helper.mock_thermal_value(self.speed_file, str(speed))


### PR DESCRIPTION
Change-Id: I75c5da25899fcdf1e3de88047a02022985aaf7e0

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes fan speed mock issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x] 201911

### Approach
#### What is the motivation for this PR?

There could be fan speed mock issue:
```python
fan1_max_speed = 26450
fan2_max_speed = 27500
mock_speed_percentage = 63

# mock value will be:
fan1_mock_speed = 26450 * 63 / 100 # 16663
fan2_mock_speed = 27500 * 63 / 100 # 17325

# In production code:
fan1_speed_percentage = 16663 // 26450 * 100 # 62, this is wrong
fan2_speed_percentage = 17325 // 27500 * 100 # 63

```

#### How did you do it?

Do a round to the mocked value

#### How did you verify/test it?

Manual test

#### Any platform specific information?

Mellanox

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
