### PR TITLE
[snmp_pdu_controller] Fix issue: should use 0 to power off Emerson PDU

### DIFF
--- a/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
+++ b/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
@@ -96,6 +96,7 @@ class snmpPduController(PduControllerBase):
             self.PORT_NAME_BASE_OID      = EMERSON_PORT_NAME_BASE_OID
             self.PORT_STATUS_BASE_OID    = EMERSON_PORT_STATUS_BASE_OID
             self.PORT_CONTROL_BASE_OID   = EMERSON_PORT_CONTROL_BASE_OID
+            self.CONTROL_OFF             = "0"
         elif self.pduType == "SENTRY4":
             self.PORT_NAME_BASE_OID      = SENTRY4_PORT_NAME_BASE_OID
             self.PORT_STATUS_BASE_OID    = SENTRY4_PORT_STATUS_BASE_OID


### PR DESCRIPTION
Change-Id: I0aeaff6e589876e7498d8016d80a89160d20aef8

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix issue: should use 0 to power off Emerson PDU

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

Control word for power off Emerson PDU should be "0", we are using "2" which is the control word of reboot. It causes  test_platform_info::test_turn_on_off_psu_and_check_psustatus failure. This PR is to fix the issue.

#### How did you do it?

If PDU type is Emerson, set power off control word to "0".

#### How did you verify/test it?

Manually run test_platform_info::test_turn_on_off_psu_and_check_psustatus

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
