### PR TITLE
[test_platform_info] Add PSU voltage related error logs to ignore list for test_turn_on_off_psu_and_check_psustatus

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -56,7 +56,8 @@ SKIP_ERROR_LOG_SHOW_PLATFORM_TEMP = ['.*ERR pmon#thermalctld.*int\(\) argument m
 SKIP_ERROR_LOG_PSU_ABSENCE = ['.*Error getting sensor data: dps460.*Kernel interface error.*',
                               '.*ERR pmon#psud:.*Fail to read model number: No key PN_VPD_FIELD in.*',
                               '.*ERR pmon#psud:.*Fail to read serial number: No key SN_VPD_FIELD in.*',
-                              '.*ERR pmon#psud:.*Fail to read revision: No key REV_VPD_FIELD in.*']
+                              '.*ERR pmon#psud:.*Fail to read revision: No key REV_VPD_FIELD in.*',
+                              '.*ERR pmon#psud: Failed to read from file /var/run/hw-management/power/psu\d_volt.*']
 
 SKIP_ERROR_LOG_SHOW_PLATFORM_TEMP.extend(SKIP_ERROR_LOG_COMMON)
 SKIP_ERROR_LOG_PSU_ABSENCE.extend(SKIP_ERROR_LOG_COMMON)


### PR DESCRIPTION
Change-Id: I6a1f215870b279bc67cffe530975a9e402f29989

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes issue log analyzer error when running test case test_turn_on_off_psu_and_check_psustatus

```
Dec 23 15:07:30.118103 r-lionfish-16 ERR pmon#psud: Failed to read from file /var/run/hw-management/power/psu2_volt_capability - FileNotFoundError(2, 'No such file or directory')
Dec 23 15:07:30.118558 r-lionfish-16 ERR pmon#psud: Failed to read from file /var/run/hw-management/power/psu2_volt_capability - FileNotFoundError(2, 'No such file or directory')
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

Add expected error message to ignore list to avoid failing the test case.

#### How did you do it?

Add expected error message to ignore list to avoid failing the test case.

#### How did you verify/test it?

Run the test case > 20 times

#### Any platform specific information?

Mellanox

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
