### PR TITLE
[Mellanox] Mock all thermal zone to normal temperature before testing dynamic minimum algorithm

### DIFF
--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -1104,6 +1104,8 @@ class MinTableMocker(object):
     FAN_AMB_PATH = 'fan_amb'
     PORT_AMB_PATH = 'port_amb'
     TRUST_PATH = 'module1_temp_fault'
+    LIST_THERMAL_ZONE_TEMPERATURE_FILE= 'ls /run/hw-management/thermal/mlxsw*/thermal_zone_temp'
+    NORMAL_TEMPERATURE = 40000
 
     def __init__(self, dut):
         self.mock_helper = MockerHelper(dut)
@@ -1130,6 +1132,12 @@ class MinTableMocker(object):
         self.mock_helper.mock_thermal_value(self.PORT_AMB_PATH, str(port_temp))
         self.mock_helper.mock_thermal_value(self.TRUST_PATH, str(trust_value))
 
+    def mock_normal_temperature(self):
+        output = self.mock_helper.dut.shell(self.THERMAL_ZONE_TEMPERATURE_PATTERN)
+        for thermal_file in output['stdout_lines']:
+            if self.mock_helper.read_value(thermal_file) != '0':
+                self.mock_helper.mock_value(thermal_file, self.NORMAL_TEMPERATURE)
+        
     def deinit(self):
         """
         Destructor of MinTableMocker.

--- a/tests/platform_tests/mellanox/test_thermal_control.py
+++ b/tests/platform_tests/mellanox/test_thermal_control.py
@@ -45,7 +45,7 @@ def test_dynamic_minimum_table(duthosts, rand_one_dut_hostname, mocker_factory):
             pytest.skip('The cooling level {} is higher than threshold {}.'.format(cooling_cur_state, COOLING_CUR_STATE_THRESHOLD))
 
         mocker = mocker_factory(duthost, 'MinTableMocker')
-
+        mocker.mock_normal_temperature()
         temperature = random.randint(0, max_temperature)
         trust_state = True if random.randint(0, 1) else False
         logger.info('Testing with temperature={}, trust_state={}'.format(temperature, trust_state))


### PR DESCRIPTION
Change-Id: I4f0214b610ffce3d61f6696cf8ffaa36a6e48c4e

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
If any thermal zone temperature exceed threshold, dynamic minimum algorithm will be disabled. It would cause test_dynamic_minimum_table fail. The fix is to mock all thermal zone to normal temperature before testing dynamic minimum algorithm.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?

If any thermal zone temperature exceed threshold, dynamic minimum algorithm will be disabled. It would cause test_dynamic_minimum_table fail. 

#### How did you do it?

The fix is to mock all thermal zone to normal temperature before testing dynamic minimum algorithm.

#### How did you verify/test it?

Manual run the test case

#### Any platform specific information?

Mellanox

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
