### PR TITLE
[system-health] Add fan dir test for system health test

### DIFF
--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -359,6 +359,8 @@ class FanDrawerData:
     # FAN direction sys fs path available in 202012 and later
     FAN_DIR_PATH_PER_FAN = '/run/hw-management/thermal/fan{}_dir'
 
+    FAN_EXPECT_DIRECTION = None
+
     def __init__(self, mock_helper, naming_rule, index):
         """
         Constructor of FAN drawer data.
@@ -489,6 +491,26 @@ class FanDrawerData:
                 return 'red'
 
         return 'green'
+
+    def mock_fan_direction_status(self, good, drawer_num):
+        if FanDrawerData.FAN_EXPECT_DIRECTION is None:
+            try:
+                FanDrawerData.FAN_EXPECT_DIRECTION = int(self.helper.read_value(
+                    FanDrawerData.FAN_DIR_PATH_PER_FAN.format(1)))
+            except SysfsNotExistError:
+                return None
+
+        if good:
+            target_dir = FanDrawerData.FAN_EXPECT_DIRECTION
+        else:
+            target_dir = 1 if FanDrawerData.FAN_EXPECT_DIRECTION == 0 else 0
+
+        self.helper.mock_value(FanDrawerData.FAN_DIR_PATH_PER_FAN.format(drawer_num), str(target_dir))
+        platform_data = get_platform_data(self.helper.dut)
+        if platform_data['fans']['hot_swappable']:
+            return FAN_NAMING_RULE['fan']['name'].format(drawer_num * MockerHelper.FAN_NUM_PER_DRAWER)
+        else:
+            return FAN_NAMING_RULE['fan']['name'].format(drawer_num)
 
 
 class FanData:

--- a/tests/system_health/device_mocker.py
+++ b/tests/system_health/device_mocker.py
@@ -31,6 +31,9 @@ class DeviceMocker:
     def mock_psu_voltage(self, good):
         return False, None
 
+    def mock_fan_direction(self, good):
+        return False, None
+
 
 @pytest.fixture
 def device_mocker_factory():

--- a/tests/system_health/mellanox/mellanox_device_mocker.py
+++ b/tests/system_health/mellanox/mellanox_device_mocker.py
@@ -110,6 +110,11 @@ class MellanoxDeviceMocker(DeviceMocker):
         return True
 
     def mock_psu_presence(self, status):
+        platform_data = get_platform_data(self.mock_helper.dut)
+        always_present = not platform_data['psus']['hot_swappable']
+        if always_present:
+            return False, None
+
         self.psu_data.mock_presence(1 if status else 0)
         return True, self.psu_data.name
 
@@ -118,6 +123,11 @@ class MellanoxDeviceMocker(DeviceMocker):
         return True, self.psu_data.name
 
     def mock_psu_temperature(self, good):
+        platform_data = get_platform_data(self.mock_helper.dut)
+        always_present = not platform_data['psus']['hot_swappable']
+        if always_present:
+            return False, None
+        
         threshold = self.psu_data.get_psu_temperature_threshold()
         if good:
             value = threshold - 1000
@@ -129,3 +139,14 @@ class MellanoxDeviceMocker(DeviceMocker):
     def mock_psu_voltage(self, good):
         # Not Supported for now
         return False, None
+
+    def mock_fan_direction(self, good):
+        platform_data = get_platform_data(self.mock_helper.dut)
+        drawer_num = platform_data['fans']['number']
+        if drawer_num < 2:
+            return False, None
+
+        fan_name = self.fan_drawer_data.mock_fan_direction_status(good, drawer_num)
+        if not fan_name:
+            return False, None
+        return True, fan_name

--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -53,6 +53,7 @@ SUMMARY_NOT_OK = 'Not OK'
 EXPECT_FAN_MISSING = '{} is missing'
 EXPECT_FAN_BROKEN = '{} is broken'
 EXPECT_FAN_INVALID_SPEED = '{} speed is out of range'
+EXPECT_FAN_INVALID_DIRECTION = '{} direction'
 EXPECT_ASIC_HOT = 'ASIC temperature is too hot'
 EXPECT_PSU_MISSING = '{} is missing or not available'
 EXPECT_PSU_NO_POWER = '{} is out of power'
@@ -254,6 +255,27 @@ def test_device_checker(duthosts, enum_rand_one_per_hwsku_hostname, device_mocke
 
             value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, psu_name)
             assert not value or psu_expect_value not in value, 'Mock PSU normal temperature, but it is still overheated'
+
+        fan_mock_result, fan_name = device_mocker.mock_fan_direction(False)
+        expect_value = EXPECT_FAN_INVALID_DIRECTION.format(fan_name)
+        if fan_mock_result:
+            logger.info('Mocked fan invalid direction for {}, waiting {} seconds for it to take effect'.format(
+                fan_name,
+                THERMAL_CHECK_INTERVAL))
+            time.sleep(THERMAL_CHECK_INTERVAL)
+            value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name)
+            assert value and expect_value in value, 'Mock fan invalid direction, expect {}, but got {}'.format(
+                expect_value,
+                value)
+
+        fan_mock_result, fan_name = device_mocker.mock_fan_direction(True)
+        if fan_mock_result:
+            logger.info('Mocked fan valid direction for {}, waiting {} seconds for it to take effect'.format(
+                fan_name,
+                THERMAL_CHECK_INTERVAL))
+            time.sleep(THERMAL_CHECK_INTERVAL)
+            value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name)
+            assert not value or expect_value not in value, 'Mock fan valid direction, but it is still invalid'
 
         mock_result, psu_name = device_mocker.mock_psu_voltage(False)
         expect_value = EXPECT_PSU_INVALID_VOLTAGE.format(psu_name)


### PR DESCRIPTION
**What I did?**

Add a mock test to mock invalid fan direction and check system-health can detect this error.

**Why I did it?**

There is an enhancement in system health to check fan directions, test case should be added to cover it.

**How I verify it?**
 
Manually run the newly added test case.