### PR TITLE
[Mellanox] Ignore checking ASIC/module temperature if thermal updater is there

### DIFF
--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -1,5 +1,6 @@
 import os
 import json
+import re
 import random
 import logging
 import time
@@ -403,6 +404,11 @@ class MockerHelper:
             return False
         else:
             return True
+        
+    def has_thermal_updater(self):
+        cmd = 'python3 -c "from sonic_platform import thermal_updater"'
+        out = self.dut.shell(cmd, module_ignore_errors=True)
+        return not out['failed']
 
 
 class FanDrawerData:
@@ -807,6 +813,8 @@ class CheckMockerResultMixin(object):
         """
         expected = {}
         for name, fields in list(self.expected_data.items()):
+            if self.excluded_entry_pattern and re.search(self.excluded_entry_pattern, name):
+                continue
             data = {}
             for idx, header in enumerate(self.expected_data_headers):
                 data[header] = fields[idx]
@@ -819,6 +827,8 @@ class CheckMockerResultMixin(object):
         mismatch_in_actual_data = []
         for actual_data_item in actual_data:
             primary = actual_data_item[self.primary_field]
+            if self.excluded_entry_pattern and re.search(self.excluded_entry_pattern, primary):
+                continue
             if primary not in expected:
                 extra_in_actual_data.append(actual_data_item)
             else:
@@ -869,6 +879,7 @@ class RandomFanStatusMocker(CheckMockerResultMixin, FanStatusMocker):
             'drawer', 'led', 'fan', 'speed', 'direction', 'presence', 'status']
         self.primary_field = 'fan'
         self.excluded_fields = ['timestamp', ]
+        self.excluded_entry_pattern = None
 
     def deinit(self):
         """
@@ -1023,6 +1034,13 @@ class RandomThermalStatusMocker(CheckMockerResultMixin, ThermalStatusMocker):
                                       'warning']
         self.primary_field = 'sensor'
         self.excluded_fields = ['timestamp', ]
+        if self.mock_helper.has_thermal_updater():
+            # if thermal updater is there, ASIC and module temperature are read from SDK sysfs.
+            # There is no way to mock SDK sysfs because it is created by kernel (user space has
+            # no permission to change it). So, we just ignore it for checking.
+            self.excluded_entry_pattern = re.compile("ASIC|(xSFP module \d+ Temp)")
+        else:
+            self.excluded_entry_pattern = None
 
     def deinit(self):
         """


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

thermal updater is a thread which will update ASIC/module thermal sysfs nodes periodically. Currently, there is no way to stop thermal updater. So, there is no easy way to mock thermal sysfs value if thermal updater is there (thermal updater will always override mocked values). 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Ignore ASIC/module thermal mock test if thermal updater is present

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
Manual test
sonic-mgmt regression test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
